### PR TITLE
feat: log metrics more frequently

### DIFF
--- a/seq2seq/do_run.sh
+++ b/seq2seq/do_run.sh
@@ -6,5 +6,6 @@ python run_seq2seq_flax.py \
 	--per_device_train_batch_size 24 \
 	--per_device_eval_batch_size 24 \
 	--preprocessing_num_workers 48 \
+	--warmup_steps 1000 \
 	--do_train \
 	--do_eval \

--- a/seq2seq/run_seq2seq_flax.py
+++ b/seq2seq/run_seq2seq_flax.py
@@ -623,17 +623,24 @@ def main():
         return traverse_util.unflatten_dict(flat_mask)
 
     # create adam optimizer
-    adamw = optax.adamw(
-        learning_rate=linear_decay_lr_schedule_fn,
-        b1=training_args.adam_beta1,
-        b2=training_args.adam_beta2,
-        eps=training_args.adam_epsilon,
-        weight_decay=training_args.weight_decay,
-        mask=decay_mask_fn,
-    )
+    if training_args.adafactor:
+        # We use the default parameters here to initialize adafactor,
+        # For more details about the parameters please check https://github.com/deepmind/optax/blob/ed02befef9bf81cbbf236be3d2b0e032e9ed4a40/optax/_src/alias.py#L74
+        optimizer = optax.adafactor(
+            learning_rate=linear_decay_lr_schedule_fn,
+        )
+    else:
+        optimizer = optax.adamw(
+            learning_rate=linear_decay_lr_schedule_fn,
+            b1=training_args.adam_beta1,
+            b2=training_args.adam_beta2,
+            eps=training_args.adam_epsilon,
+            weight_decay=training_args.weight_decay,
+            mask=decay_mask_fn,
+        )
 
     # Setup train state
-    state = TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw, dropout_rng=dropout_rng)
+    state = TrainState.create(apply_fn=model.__call__, params=model.params, tx=optimizer, dropout_rng=dropout_rng)
 
     # label smoothed cross entropy
     def loss_fn(logits, labels, padding_mask, label_smoothing_factor=0.0):

--- a/seq2seq/run_seq2seq_flax.py
+++ b/seq2seq/run_seq2seq_flax.py
@@ -216,7 +216,7 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
     )
     log_interval: Optional[int] = field(
-        default=500,
+        default=5,
         metadata={
             "help": "For debugging purposes or quicker training, truncate the number of training examples to this "
             "value if set."
@@ -753,7 +753,7 @@ def main():
 
             if global_step % data_args.log_interval == 0 and jax.process_index() == 0:
                 for k, v in unreplicate(train_metric).items():
-                    wandb.log(f{'train/{k}': jax.device_get(v), step=global_step)
+                    wandb.log(f{'train/{k}': jax.device_get(v)}, step=global_step)
 
         train_time += time.time() - train_start
 


### PR DESCRIPTION
This will log metrics every 500 steps by default within `train` group.
The regular metrics are still logged at the end of epoch but are moved to `eval` and `train_epoch` groups