### PR TITLE
change bart-large-cnn to bart-large in demo folder

### DIFF
--- a/demo/CustomBARTv4b_model-generate.ipynb
+++ b/demo/CustomBARTv4b_model-generate.ipynb
@@ -141,7 +141,7 @@
         "OUTPUT_VOCAB_SIZE = 16384 + 1  # encoded image token space + 1 for bos\n",
         "OUTPUT_LENGTH = 256 + 1  # number of encoded tokens + 1 for bos\n",
         "BOS_TOKEN_ID = 16384\n",
-        "BASE_MODEL = 'facebook/bart-large-cnn'"
+        "BASE_MODEL = 'facebook/bart-large'"
       ],
       "execution_count": 3,
       "outputs": []


### PR DESCRIPTION
This PR changes the base model from `facebook/bart-large-cnn` to `facebook-bart-large`, as suggested by Suraj.

He suggested that the CNN model is fine-tuned for summarization, and hence might not be a great fit for our purpose.