### PR TITLE
open external link in new tab preventing breaking of demo

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -46,7 +46,7 @@ DALL·E mini is an AI model that generates images from any prompt you give!
 <p style='text-align: center'>
 Created by Boris Dayma et al. 2021
 <br/>
-<a href="https://github.com/borisdayma/dalle-mini">GitHub</a> | <a href="https://wandb.ai/dalle-mini/dalle-mini/reports/DALL-E-mini--Vmlldzo4NjIxODA">Project Report</a>
+<a href="https://github.com/borisdayma/dalle-mini" target="_blank">GitHub</a> | <a href="https://wandb.ai/dalle-mini/dalle-mini/reports/DALL-E-mini--Vmlldzo4NjIxODA" target="_blank">Project Report</a>
 </p>
         """, unsafe_allow_html=True)
 


### PR DESCRIPTION
Previously, the external links in the pages, when clicked, opened on the same browser tab, which was true even in the cases of the Hugging Face Space.

* The pages loaded only incompletely,
* and no images were loaded,
* and not to mention, the demo page exited to a new page which was defunct.

This PR fixes #64.

It just adds two attributes to the `<a>` tags inside the Streamlit's markdown feature, like so:

```html
<a href='link/to/github' target="_blank">GitHub</a>
```

This is according to [this SO entry](https://stackoverflow.com/a/4425223).

At first, I thought of solving it by using `kramdown` type formatting like this-

```md
[text](link){:target="_blank"}
```


But, [`streamlit.markdown()`](https://docs.streamlit.io/en/stable/api.html#streamlit.markdown) only supports [Github-flavored Markdown](https://github.github.com/gfm), and this was not supported.

And since we are already using HTML, which is discouraged by Streamlit, this seems to be the best fix.