### PR TITLE
feat: 🥑 theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ---
 title: DALL·E mini
 emoji: 🥑
-colorFrom: red
-colorTo: purple
+colorFrom: yellow
+colorTo: green
 sdk: streamlit
 app_file: app/app.py
 pinned: false


### PR DESCRIPTION
When sharing our app, we currently see:
![image](https://user-images.githubusercontent.com/715491/127242801-dcd3528c-924e-4113-949e-9abc494e3383.png)

What about some 🥑 colors:
![image](https://user-images.githubusercontent.com/715491/127242758-62e7ab8e-51d2-4f44-81e2-5ce888cfe072.png)

