### PR TITLE
reference citations and pseudo BibTex for dalle mini added

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,8 @@ keywords:
   - "zero-shot"
   - JAX
 license: "Apache-2.0"
-message: "If you use this software, please cite it using these metadata."
+doi: 10.5281/zenodo.1234
+message: "If you use this project, please cite it using these metadata."
 repository-code: "https://github.com/borisdayma/dalle-mini"
 title: "DALL·E Mini"
 version: "v0.1-alpha"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,7 +36,7 @@ keywords:
   - "zero-shot"
   - JAX
 license: "Apache-2.0"
-doi: 10.5281/zenodo.1234
+doi: 10.5281/zenodo.5146400
 message: "If you use this project, please cite it using these metadata."
 repository-code: "https://github.com/borisdayma/dalle-mini"
 title: "DALL·E Mini"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you find DALL·E mini useful in your research or wish to refer, please use th
 ```
 @misc{Dayma_DALL·E_Mini_2021,
 author = {Dayma, Boris and Patil, Suraj and Cuenca, Pedro and Saifullah, Khalid and Abraham, Tanishq and Lê Khắc, Phúc and Melas, Luke and Ghosh, Ritobrata},
-doi = {10.5281/zenodo.1234},
+doi = {10.5281/zenodo.5146400},
 month = {7},
 title = {DALL·E Mini},
 url = {https://github.com/borisdayma/dalle-mini},

--- a/README.md
+++ b/README.md
@@ -86,14 +86,13 @@ The "armchair in the shape of an avocado" was used by OpenAI when releasing DALL
 If you find DALL·E mini useful in your research or wish to refer, please use the following BibTeX entry.
 
 ```
-@misc{dalle_mini2021,
-  author = {Boris Dayma, Suraj Patil, Pedro Cuenca, Khalid Saifullah, Tanishq Abraham, Phúc Lê Khắc, Luke Melas, Ritobrata Ghosh},
-  title = {DALL·E mini},
-  year = {2021},
-  publisher = {GitHub},
-  journal = {GitHub repository},
-  doi = {10.5281/zenodo.4414861},
-  howpublished = {\url{https://github.com/borisdayma/dalle-mini}}
+@misc{Dayma_DALL·E_Mini_2021,
+author = {Dayma, Boris and Patil, Suraj and Cuenca, Pedro and Saifullah, Khalid and Abraham, Tanishq and Lê Khắc, Phúc and Melas, Luke and Ghosh, Ritobrata},
+doi = {10.5281/zenodo.1234},
+month = {7},
+title = {DALL·E Mini},
+url = {https://github.com/borisdayma/dalle-mini},
+year = {2021}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ If you find DALL·E mini useful in your research or wish to refer, please use th
   doi = {10.5281/zenodo.4414861},
   howpublished = {\url{https://github.com/borisdayma/dalle-mini}}
 }
-
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -80,3 +80,66 @@ The "armchair in the shape of an avocado" was used by OpenAI when releasing DALL
 
 - 🤗 Hugging Face for organizing [the FLAX/JAX community week](https://github.com/huggingface/transformers/tree/master/examples/research_projects/jax-projects)
 - Google Cloud team for providing access to TPU's
+
+## Citing DALL·E mini
+
+If you find DALL·E mini useful in your research or wish to refer, please use the following BibTeX entry.
+
+```
+@misc{dalle_mini2021,
+  author = {Boris Dayma, Suraj Patil, Pedro Cuenca, Khalid Saifullah, Tanishq Abraham, Phúc Lê Khắc, Luke Melas, Ritobrata Ghosh},
+  title = {DALL·E mini},
+  year = {2021},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  doi = {10.5281/zenodo.4414861},
+  howpublished = {\url{https://github.com/borisdayma/dalle-mini}}
+}
+
+```
+
+## References
+
+```
+@misc{ramesh2021zeroshot,
+      title={Zero-Shot Text-to-Image Generation}, 
+      author={Aditya Ramesh and Mikhail Pavlov and Gabriel Goh and Scott Gray and Chelsea Voss and Alec Radford and Mark Chen and Ilya Sutskever},
+      year={2021},
+      eprint={2102.12092},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+```
+@misc{esser2021taming,
+      title={Taming Transformers for High-Resolution Image Synthesis}, 
+      author={Patrick Esser and Robin Rombach and Björn Ommer},
+      year={2021},
+      eprint={2012.09841},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```
+
+```
+@misc{lewis2019bart,
+      title={BART: Denoising Sequence-to-Sequence Pre-training for Natural Language Generation, Translation, and Comprehension}, 
+      author={Mike Lewis and Yinhan Liu and Naman Goyal and Marjan Ghazvininejad and Abdelrahman Mohamed and Omer Levy and Ves Stoyanov and Luke Zettlemoyer},
+      year={2019},
+      eprint={1910.13461},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL}
+}
+```
+
+```
+@misc{radford2021learning,
+      title={Learning Transferable Visual Models From Natural Language Supervision}, 
+      author={Alec Radford and Jong Wook Kim and Chris Hallacy and Aditya Ramesh and Gabriel Goh and Sandhini Agarwal and Girish Sastry and Amanda Askell and Pamela Mishkin and Jack Clark and Gretchen Krueger and Ilya Sutskever},
+      year={2021},
+      eprint={2103.00020},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```


### PR DESCRIPTION
Reference citations were added in the README.md for some prime papers for our project as mentioned by @borisdayma in [#77](https://github.com/borisdayma/dalle-mini/issues/77). I've also added a pseudo BibTex for our own project to evaluate if things look good. We can update it once we've our own BibTex entry generated.

This is how it kind of looks like:
![image](https://user-images.githubusercontent.com/26279642/127628298-28f2032f-6c1c-4fbf-918c-03cad5941de3.png)