### PR TITLE
Add --rm flag to default docker run command

### DIFF
--- a/run_docker_image.sh
+++ b/run_docker_image.sh
@@ -2,4 +2,4 @@
 
 # This script is used to run the docker image. Change or remove GPU flag if you dont have nvidia-docker or the needed GPUs
 current_dir=$(pwd)
-docker run -it -p 8888:8888  --gpus all  -v $current_dir:/workspace dalle-mini:latest
+docker run --rm -it -p 8888:8888  --gpus all  -v $current_dir:/workspace dalle-mini:latest


### PR DESCRIPTION
Another small PR to ensure that the docker container cleans up after itself when run using `run_docker_image.sh`.
