### PR TITLE
doc(README): link to Replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ You can also use these great projects from the community:
 * spin off your own app with [DALL-E Playground repository](https://github.com/saharmor/dalle-playground) (thanks [Sahar](https://twitter.com/theaievangelist))
 
 * try [DALL·E Flow](https://github.com/jina-ai/dalle-flow) project for generating, diffusion, upscaling in a Human-in-the-Loop workflow (thanks [Han Xiao](https://github.com/hanxiao))
-
-* [run on Replicate](https://replicate.com/borisdayma/dalle-mini), in the browser or via API
   
   [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/dalle-flow/blob/main/client.ipynb)
+
+* run on [Replicate](https://replicate.com/borisdayma/dalle-mini), in the browser or via API
 
 ## How does it work?
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You can also use these great projects from the community:
 
 * try [DALL·E Flow](https://github.com/jina-ai/dalle-flow) project for generating, diffusion, upscaling in a Human-in-the-Loop workflow (thanks [Han Xiao](https://github.com/hanxiao))
 
+* [run on Replicate](https://replicate.com/borisdayma/dalle-mini), in the browser or via API
+  
   [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jina-ai/dalle-flow/blob/main/client.ipynb)
 
 ## How does it work?


### PR DESCRIPTION
Hey @borisdayma! 👋 

We've loved seeing all the dalle-mini output on Twitter!

We've made another web interface for it on Replicate: https://replicate.com/borisdayma/dalle-mini

<img width="1183" alt="dalle-replicate" src="https://user-images.githubusercontent.com/70536672/173705539-89b05500-4506-4e62-870e-39abb58d9eed.png">

Replicate's backed by a big auto-scaling cluster of A100s, so it should be able to handle a lot of load (famous last words 😂). We also have an [API](https://replicate.com/docs/api), so people can run dalle-mini from their own code without having to set up servers etc:

```py
import replicate
model = replicate.models.get("borisdayma/dalle-mini")
model.predict(prompt="sunset over a lake in the mountains")
```

This pull request includes the configuration for [Cog](https://github.com/replicate/cog), a tool for packaging models in a standard format. Replicate uses this format to run the model.

[Claim your page here](https://replicate.com/borisdayma/dalle-mini/claim) so you can edit it, and we'll feature it on our website and tweet about it too.

In case you're wondering who I am, I'm from [Replicate](https://replicate.com/home), where we're trying to make machine learning reproducible. We got frustrated that we couldn't run all the really interesting ML work being done. So, we're going round implementing models we like. 😊