### PR TITLE
Solves #260 by changing the Dockerfile to use a specified version of jaxlib

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,19 +3,19 @@ FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
 ARG device_type=auto
 
 RUN apt-get update && apt-get install -y \
-  git \
-  python3 \
-  python3-pip \
-  && rm -rf /var/lib/apt/lists/*
+    git \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$device_type" = "auto" ]; then \
-  pip install --upgrade "jax[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
+    pip install --upgrade "jax[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
 
 RUN if [ "$device_type" = "nocuda" ]; then \
-  pip install --upgrade "jax[nocuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
+    pip install --upgrade "jax[nocuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
 
 RUN if [ "$device_type" = "cuda" ]; then \
-  pip install --upgrade "jaxlib[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html; fi
+    pip install --upgrade "jaxlib[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html; fi
 
 RUN pip install jupyter
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,8 +6,12 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
-  && pip install -q \
+RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+  pip install -q \
+  git+https://github.com/borisdayma/dalle-mini.git \
+  git+https://github.com/patil-suraj/vqgan-jax.git \
+|| pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
+  pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
   git+https://github.com/patil-suraj/vqgan-jax.git
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,19 +1,30 @@
 FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
 
+ARG device_type=auto
+
 RUN apt-get update && apt-get install -y \
   git \
   python3 \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+RUN if [ "$device_type" = "auto" ]; then \
+  pip install --upgrade "jax[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
   pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git \
-|| pip install --upgrade https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn82-cp38-none-manylinux2014_x86_64.whl \
+  git+https://github.com/patil-suraj/vqgan-jax.git; fi
+
+RUN if [ "$device_type" = "cpu" ]; then \
+  pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
   pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git
+  git+https://github.com/patil-suraj/vqgan-jax.git; fi
+
+RUN if [ "$device_type" = "gpu" ]; then \
+  pip install --upgrade https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn805-cp38-none-manylinux2014_x86_64.whl \
+  pip install -q \
+  git+https://github.com/borisdayma/dalle-mini.git \
+  git+https://github.com/patil-suraj/vqgan-jax.git; fi
 
 RUN pip install jupyter
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -9,22 +9,13 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$device_type" = "auto" ]; then \
-  pip install --upgrade "jax[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
-  pip install -q \
-  git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git; fi
+  pip install --upgrade "jax[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
 
-RUN if [ "$device_type" = "cpu" ]; then \
-  pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
-  pip install -q \
-  git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git; fi
+RUN if [ "$device_type" = "nocuda" ]; then \
+  pip install --upgrade "jax[nocuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html; fi
 
-RUN if [ "$device_type" = "gpu" ]; then \
-  pip install --upgrade https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn805-cp38-none-manylinux2014_x86_64.whl \
-  pip install -q \
-  git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git; fi
+RUN if [ "$device_type" = "cuda" ]; then \
+  pip install --upgrade "jaxlib[cuda11]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html; fi
 
 RUN pip install jupyter
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-rele
   pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
   git+https://github.com/patil-suraj/vqgan-jax.git \
-|| pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
+|| pip install --upgrade https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn82-cp38-none-manylinux2014_x86_64.whl \
   pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
   git+https://github.com/patil-suraj/vqgan-jax.git

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+RUN pip install --upgrade https://storage.googleapis.com/jax-releases/nocuda/jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl \
   && pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
   git+https://github.com/patil-suraj/vqgan-jax.git
@@ -14,4 +14,3 @@ RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-rele
 RUN pip install jupyter
 
 WORKDIR /workspace
-

--- a/Docker/build_docker.sh
+++ b/Docker/build_docker.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 DEVICE=auto
 
 case "$1" in

--- a/Docker/build_docker.sh
+++ b/Docker/build_docker.sh
@@ -1,8 +1,8 @@
 DEVICE=auto
 
 case "$1" in
---cpu) DEVICE=cpu ;;
---gpu) DEVICE=gpu ;;
+--cuda) DEVICE=cuda ;;
+--nocuda) DEVICE=nocuda ;;
 --auto) DEVICE=auto ;;
 esac
 shift

--- a/Docker/build_docker.sh
+++ b/Docker/build_docker.sh
@@ -1,1 +1,10 @@
-docker build . -t dalle-mini:latest
+DEVICE=auto
+
+case "$1" in
+--cpu) DEVICE=cpu ;;
+--gpu) DEVICE=gpu ;;
+--auto) DEVICE=auto ;;
+esac
+shift
+
+docker build . -t dalle-mini:latest --build-arg device_type=$DEVICE


### PR DESCRIPTION
Specifies the exact version of jaxlib if it returns the following error:
```
#5 12.13 ERROR: No matching distribution found for jaxlib==0.3.10+cuda11.cudnn82 (from jax[cuda])
------
executor failed running [/bin/sh -c pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html   && pip install -q   git+https://github.com/borisdayma/dalle-mini.git   git+https://github.com/patil-suraj/vqgan-jax.git]: exit code: 1
```