### PR TITLE
feat(docker): Update Dockerfile 🐳  to use `tensorflow:latest-gpu` image

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,17 +1,15 @@
-FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
+# Use the tensorflow image as base for CUDA compatibility
+FROM tensorflow/tensorflow:latest-gpu
 
-RUN apt-get update && apt-get install -y \
-  git \
-  python3 \
-  python3-pip \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+		python3 \
+		python3-pip \
+		&& apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
-  && pip install -q \
-  git+https://github.com/borisdayma/dalle-mini.git \
-  git+https://github.com/patil-suraj/vqgan-jax.git
-
-RUN pip install jupyter
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel jupyter
+RUN pip install --use-deprecated=html5lib jax[cuda11_cudnn82] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+RUN pip install -q git+https://github.com/borisdayma/dalle-mini.git
+RUN pip install -q git+https://github.com/patil-suraj/vqgan-jax.git
 
 WORKDIR /workspace
-


### PR DESCRIPTION
The initial base image used often causes a lot of errors between python versions, pip version, JAX versions and CUDA versions as made evident by #260, #234 and #233. 

This PR substitutes the base image for the official tensorflow GPU image which is better compatible with JAX versions and is smaller than the NVIDIA Image. ([3.77GB](https://hub.docker.com/layers/cuda/nvidia/cuda/11.6.2-cudnn8-devel-ubuntu20.04/images/sha256-d6e31961fb18e6db31a90f9a469f99b4885e9d8c95bdcd6f255f23f2fc102755?context=explore) vs [2.6GB](https://hub.docker.com/layers/tensorflow/tensorflow/tensorflow/latest-gpu/images/sha256-a34c2420739cd5a7b5662449bc21eb32d3d1c98063726ae2bd7db819cc93d72f?context=explore))

We also update to the latest versions of `pip` and `setuptools` for best compatibility along with a couple of other best practices such as `--no-install-recommends`, `--no-cache-dir` and `apt-get clean`.