### PR TITLE
Fix URL for jax cuda pip package

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html \
+RUN pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
   && pip install -q \
   git+https://github.com/borisdayma/dalle-mini.git \
   git+https://github.com/patil-suraj/vqgan-jax.git


### PR DESCRIPTION
Image fails to build because it appears the url changed