### PR TITLE
feat: train embedding layers only

### DIFF
--- a/src/dalle_mini/model/modeling.py
+++ b/src/dalle_mini/model/modeling.py
@@ -1395,7 +1395,7 @@ class DalleBart(PretrainedFromWandbMixin, FlaxBartForConditionalGeneration):
     def num_params(self, params=None):
         if params is None:
             params = self.params
-        num_params = jax.tree_map(
+        num_params = jax.tree_util.tree_map(
             lambda param: param.size, flatten_dict(unfreeze(params))
         ).values()
         return sum(list(num_params))

--- a/tools/train/train.py
+++ b/tools/train/train.py
@@ -44,6 +44,7 @@ from flax.core.frozen_dict import FrozenDict, freeze, unfreeze
 from flax.serialization import from_bytes, to_bytes
 from flax.training.common_utils import onehot
 from jax.experimental import PartitionSpec, maps
+from jax.experimental.compilation_cache import compilation_cache as cc
 from jax.experimental.pjit import pjit, with_sharding_constraint
 from scalable_shampoo.distributed_shampoo import GraftingType, distributed_shampoo
 from tqdm import tqdm
@@ -64,6 +65,8 @@ except:
     storage = None
 
 logger = logging.getLogger(__name__)
+
+cc.initialize_cache("jax_cache")
 
 
 @dataclass

--- a/tools/train/train.py
+++ b/tools/train/train.py
@@ -671,11 +671,9 @@ def main():
         for k in ["dropout", "activation_dropout", "attention_dropout"]
         if getattr(model_args, k) is not None
     }
+    config_args["gradient_checkpointing"] = training_args.gradient_checkpointing
     if model_args.config_name:
         config = DalleBartConfig.from_pretrained(model_args.config_name)
-        config.gradient_checkpointing = training_args.gradient_checkpointing
-        for k, v in config_args.items():
-            setattr(config, k, v)
     else:
         config = None
 
@@ -686,9 +684,7 @@ def main():
             config=config,
             seed=training_args.seed_model,
             dtype=getattr(jnp, model_args.dtype),
-            _do_init=False,  # we overwrite them with loaded checkpoint
-            gradient_checkpointing=training_args.gradient_checkpointing,
-            **config_args,
+            _do_init=False,
         )
     else:
         model = DalleBart(
@@ -698,6 +694,8 @@ def main():
             _do_init=False,
         )
         params = None
+    for k, v in config_args.items():
+        setattr(model.config, k, v)
     params_shape = model.params_shape_tree
 
     # get model metadata

--- a/tools/train/train.py
+++ b/tools/train/train.py
@@ -471,7 +471,8 @@ class TrainingArguments:
         default=False, metadata={"help": "Train only embedding layers."}
     )
     init_embeddings: bool = field(
-        default=False, metadata={"help": "When training embedding layers, initialize them."}
+        default=False,
+        metadata={"help": "When training embedding layers, initialize them."},
     )
 
     wandb_entity: Optional[str] = field(
@@ -628,7 +629,7 @@ def init_embeddings(model, params):
     ]
 
     # Note: using private _missing_keys
-    init_keys = {tuple(k.split('.')) for k in trainable_keypaths}
+    init_keys = {tuple(k.split(".")) for k in trainable_keypaths}
     model._missing_keys = init_keys
     return model.init_weights(model.key, model.input_shape, params=params)
 

--- a/tools/train/train.py
+++ b/tools/train/train.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional
 
@@ -972,9 +973,8 @@ def main():
                     p = jax.eval_shape(lambda x: jax.tree_map(lambda y: y[0], x), p)
                 if training_args.optim == "adam":
                     opt_state_spec[k] = jax.tree_map(
-                        _opt_state_spec_per_leaf,
+                        partial(_opt_state_spec_per_leaf, spec=split_spec[k]),
                         opt_state_shape[k],
-                        split_spec[k],
                         # return None spec for empty elements
                         is_leaf=lambda x: isinstance(x, (FrozenDict, optax.EmptyState)),
                     )


### PR DESCRIPTION
Train embedding layers only following logic of #290 but splitting out the trainable parameters function (so that it can be used independently for PartitionSpec's).