### PR TITLE
feat(utils.py): add api_key default argument 

### DIFF
--- a/src/dalle_mini/model/utils.py
+++ b/src/dalle_mini/model/utils.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Optional
+
 import wandb
 
 

--- a/src/dalle_mini/model/utils.py
+++ b/src/dalle_mini/model/utils.py
@@ -12,6 +12,11 @@ class PretrainedFromWandbMixin:
         Initializes from a wandb artifact or delegates loading to the superclass.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:  # avoid multiple artifact copies
+            # retrieve api_key if passed as a kwarg
+            api_key = None
+            if "api_key" in kwargs:
+                api_key = kwargs["api_key"]
+
             if ":" in pretrained_model_name_or_path and not os.path.isdir(
                 pretrained_model_name_or_path
             ):
@@ -19,7 +24,8 @@ class PretrainedFromWandbMixin:
                 if wandb.run is not None:
                     artifact = wandb.run.use_artifact(pretrained_model_name_or_path)
                 else:
-                    artifact = wandb.Api().artifact(pretrained_model_name_or_path)
+                    # pass api_key if set, otherwise a prompt will display to enter the key
+                    artifact = wandb.Api(api_key=api_key).artifact(pretrained_model_name_or_path)
                 pretrained_model_name_or_path = artifact.download(tmp_dir)
 
             return super(PretrainedFromWandbMixin, cls).from_pretrained(

--- a/src/dalle_mini/model/utils.py
+++ b/src/dalle_mini/model/utils.py
@@ -7,16 +7,11 @@ import wandb
 
 class PretrainedFromWandbMixin:
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, api_key=None, *model_args, **kwargs):
         """
         Initializes from a wandb artifact or delegates loading to the superclass.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:  # avoid multiple artifact copies
-            # retrieve api_key if passed as a kwarg
-            api_key = None
-            if "api_key" in kwargs:
-                api_key = kwargs["api_key"]
-
             if ":" in pretrained_model_name_or_path and not os.path.isdir(
                 pretrained_model_name_or_path
             ):

--- a/src/dalle_mini/model/utils.py
+++ b/src/dalle_mini/model/utils.py
@@ -7,7 +7,13 @@ import wandb
 
 class PretrainedFromWandbMixin:
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, api_key: Optional[str] = None, *model_args, **kwargs):
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path,
+        api_key: Optional[str] = None,
+        *model_args,
+        **kwargs
+    ):
         """
         Initializes from a wandb artifact or delegates loading to the superclass.
         """
@@ -20,7 +26,9 @@ class PretrainedFromWandbMixin:
                     artifact = wandb.run.use_artifact(pretrained_model_name_or_path)
                 else:
                     # pass api_key if set, otherwise a prompt will display to enter the key
-                    artifact = wandb.Api(api_key=api_key).artifact(pretrained_model_name_or_path)
+                    artifact = wandb.Api(api_key=api_key).artifact(
+                        pretrained_model_name_or_path
+                    )
                 pretrained_model_name_or_path = artifact.download(tmp_dir)
 
             return super(PretrainedFromWandbMixin, cls).from_pretrained(

--- a/src/dalle_mini/model/utils.py
+++ b/src/dalle_mini/model/utils.py
@@ -1,13 +1,13 @@
 import os
 import tempfile
 from pathlib import Path
-
+from typing import Optional
 import wandb
 
 
 class PretrainedFromWandbMixin:
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, api_key=None, *model_args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, api_key: Optional[str] = None, *model_args, **kwargs):
         """
         Initializes from a wandb artifact or delegates loading to the superclass.
         """


### PR DESCRIPTION
I propose Including `api_key` as a default argument to allow for api keys to be loaded programmatically instead of being passed through standard input.

This change is non-breaking, and would  allow users to simply exclude the `api_key` argument in order to authenticate via standard input.

Relevant link to the wandb api source code where I found the variable: https://github.com/wandb/wandb/blob/ef0c5226db719dd0c1351aa2fde3be5b6cd5ccbb/wandb/apis/public.py#L362