### PR TITLE
fix: remove magneto cross-attn's ln and init

### DIFF
--- a/src/dalle_mini/model/modeling.py
+++ b/src/dalle_mini/model/modeling.py
@@ -315,12 +315,18 @@ class FlaxBartAttention(FlaxBartAttention):
         )
         self.v_proj = dense(
             kernel_init=deepnet_init(self.config.init_std, gain)
-            if (self.config.use_deepnet_scaling or (self.config.use_subln_init and not self.is_cross_attention))
+            if (
+                self.config.use_deepnet_scaling
+                or (self.config.use_subln_init and not self.is_cross_attention)
+            )
             else jax.nn.initializers.normal(self.config.init_std)
         )
         self.out_proj = dense(
             kernel_init=deepnet_init(self.config.init_std, gain)
-            if (self.config.use_deepnet_scaling or (self.config.use_subln_init and not self.is_cross_attention))
+            if (
+                self.config.use_deepnet_scaling
+                or (self.config.use_subln_init and not self.is_cross_attention)
+            )
             else jax.nn.initializers.normal(self.config.init_std)
         )
         self.dropout_layer = nn.Dropout(rate=self.dropout)

--- a/src/dalle_mini/model/modeling.py
+++ b/src/dalle_mini/model/modeling.py
@@ -281,6 +281,7 @@ class FlaxBartAttention(FlaxBartAttention):
     """
 
     is_encoder: bool = False
+    is_cross_attention: bool = False
     q_length: int = None
     k_length: int = None
 
@@ -303,7 +304,7 @@ class FlaxBartAttention(FlaxBartAttention):
             gain = deepnet_gain["encoder" if self.is_encoder else "decoder"]["beta"](
                 self.config
             )
-        elif self.config.use_subln_init:
+        elif self.config.use_subln_init and not self.is_cross_attention:
             gain = subln_gain["encoder" if self.is_encoder else "decoder"](self.config)
 
         self.q_proj = dense(
@@ -314,12 +315,12 @@ class FlaxBartAttention(FlaxBartAttention):
         )
         self.v_proj = dense(
             kernel_init=deepnet_init(self.config.init_std, gain)
-            if (self.config.use_deepnet_scaling or self.config.use_subln_init)
+            if (self.config.use_deepnet_scaling or (self.config.use_subln_init and not self.is_cross_attention))
             else jax.nn.initializers.normal(self.config.init_std)
         )
         self.out_proj = dense(
             kernel_init=deepnet_init(self.config.init_std, gain)
-            if (self.config.use_deepnet_scaling or self.config.use_subln_init)
+            if (self.config.use_deepnet_scaling or (self.config.use_subln_init and not self.is_cross_attention))
             else jax.nn.initializers.normal(self.config.init_std)
         )
         self.dropout_layer = nn.Dropout(rate=self.dropout)
@@ -346,7 +347,7 @@ class FlaxBartAttention(FlaxBartAttention):
                 jnp.ones((1, self.config.image_length), dtype="bool"), dtype="bool"
             )
 
-        if self.config.ln_positions in ["subln"]:
+        if self.config.ln_positions in ["subln"] and not self.is_cross_attention:
             self.mid_layernorm = norm(
                 self.config.ln_type, dtype=self.dtype, epsilon=1e-05
             )
@@ -473,7 +474,7 @@ class FlaxBartAttention(FlaxBartAttention):
             attn_output = attn_output * self.head_scale
         attn_output = self._merge_heads(attn_output)
 
-        if self.config.ln_positions in ["subln"]:
+        if self.config.ln_positions in ["subln"] and not self.is_cross_attention:
             attn_output = self.mid_layernorm(attn_output)
 
         attn_output = self.out_proj(attn_output)
@@ -655,6 +656,7 @@ class FlaxBartEncoderLayer(nn.Module):
             bias=self.config.use_bias,
             dtype=self.dtype,
             is_encoder=True,
+            is_cross_attention=False,
             q_length=self.config.max_text_length,
             k_length=self.config.max_text_length,
         )(hidden_states=hidden_states, attention_mask=attention_mask)
@@ -765,6 +767,7 @@ class FlaxBartDecoderLayer(nn.Module):
             bias=self.config.use_bias,
             dtype=self.dtype,
             is_encoder=False,
+            is_cross_attention=False,
             q_length=self.config.image_length,
             k_length=self.config.image_length,
         )(
@@ -805,6 +808,7 @@ class FlaxBartDecoderLayer(nn.Module):
                 bias=self.config.use_bias,
                 dtype=self.dtype,
                 is_encoder=False,
+                is_cross_attention=True,
                 q_length=self.config.image_length,
                 k_length=self.config.max_text_length,
             )(


### PR DESCRIPTION
Hi @borisdayma ,

Thanks for the fantastic work on adding Magneto to the repo.

Magneto doesn't use _subln_ for the cross-attention layer, so there is no need to either add an extra LayerNorm or scale the initialization for it (see the end of Sec. 2 in the [paper](https://arxiv.org/abs/2210.06423)). Here, I open a pull request to remove the middle LayerNorm and DeepNet init of the cross-attention, as it proves to have an effect on the performance in our experiments.

![image](https://user-images.githubusercontent.com/8328033/197686046-ee280de0-d83f-4360-abc1-66ecb0fd159a.png)
