### PR TITLE
docs(docker): fix build & run script names

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -6,8 +6,8 @@ This folder contains the Dockerfile needed to build a Docker image that can easi
 
 Steps to run inference with Dalle-mini are as follows:
 
-1. Build the docker image with ```dalle-mini/Docker/build_image.sh```
-2. Run the container with ```dalle-mini/run_docker_image```
+1. Build the docker image with ```dalle-mini/Docker/build_docker.sh```
+2. Run the container with ```dalle-mini/run_docker_image.sh```
 3. Navigate to ```/workspace/tools/inference/``` and run ```run_infer_notebook.sh```
 4. Click the Jupyter Notebook link and run through the notebook.
 


### PR DESCRIPTION
Small PR to address a few issues in the docker README:

- Fixed the name of the script responsible for building the docker image (changed `build_image.sh` to `build_docker.sh`).

- Added the missing `.sh` extension for the `run_docker_image.sh` script.
