### PR TITLE
fix: adapt to new jax API

### DIFF
--- a/src/dalle_mini/model/modeling.py
+++ b/src/dalle_mini/model/modeling.py
@@ -1599,8 +1599,8 @@ class DalleBart(PretrainedFromWandbMixin, FlaxBartForConditionalGeneration):
         self,
         decoder_input_ids,
         max_length,
-        attention_mask: Optional[jnp.DeviceArray] = None,
-        decoder_attention_mask: Optional[jnp.DeviceArray] = None,
+        attention_mask: Optional[jax.Array] = None,
+        decoder_attention_mask: Optional[jax.Array] = None,
         encoder_outputs=None,
         **kwargs,
     ):

--- a/src/dalle_mini/model/partitions.py
+++ b/src/dalle_mini/model/partitions.py
@@ -2,7 +2,7 @@ import re
 
 from flax.core.frozen_dict import freeze
 from flax.traverse_util import flatten_dict, unflatten_dict
-from jax.experimental import PartitionSpec as P
+from jax.sharding import PartitionSpec as P
 
 # utils adapted from https://github.com/google-research/google-research/blob/master/flax_models/t5x/partitions.py
 # Sentinels


### PR DESCRIPTION
Tests are currently broken when ran with the latest version of JAX installed.
This patch ensures the code compatibility with the current jax API.